### PR TITLE
fix: create session table if SESSION_DRIVER is database

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -100,7 +100,7 @@ then
 fi
 
 if [ "${SESSION_DRIVER}" == "database" ]; then
-  cp -a /var/www/html/vendor/laravel/framework/src/Illuminate/Session/Console/stubs/database.stub /var/www/html/database/migrations/create_sessions_table.php
+  cp -a /var/www/html/vendor/laravel/framework/src/Illuminate/Session/Console/stubs/database.stub /var/www/html/database/migrations/2021_05_06_0000_create_sessions_table.php
 fi
 
 # Create laravel log file

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -99,6 +99,10 @@ then
   cp -a /var/www/html/vendor/laravel/passport/database/migrations/* /var/www/html/database/migrations/
 fi
 
+if [ "${SESSION_DRIVER}" == "database" ]; then
+  cp -a /var/www/html/vendor/laravel/framework/src/Illuminate/Session/Console/stubs/database.stub /var/www/html/database/migrations/create_sessions_table.php
+fi
+
 # Create laravel log file
 touch /var/www/html/storage/logs/laravel.log
 # Add correct permissions for files and directories

--- a/docker/entrypoint_alpine.sh
+++ b/docker/entrypoint_alpine.sh
@@ -45,6 +45,10 @@ then
   cp -a /var/www/html/vendor/laravel/passport/database/migrations/* /var/www/html/database/migrations/
 fi
 
+if [ "${SESSION_DRIVER}" == "database" ]; then
+  cp -a /var/www/html/vendor/laravel/framework/src/Illuminate/Session/Console/stubs/database.stub /var/www/html/database/migrations/2021_05_06_0000_create_sessions_table.php
+fi
+
 php artisan migrate --force
 php artisan config:clear
 php artisan config:cache

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -72,8 +72,8 @@ fi
 
 exec supervisord -c /supervisord.conf
 
-if [ "${SESSION_DRIVER}" == "database"]; then
-  php artisan session:table
+if [ "${SESSION_DRIVER}" == "database" ]; then
+  cp -ax /var/www/html/vendor/laravel/framework/src/Illuminate/Session/Console/stubs/database.stub /var/www/html/database/migrations/create_sessions_table.php
 fi
 
 php artisan migrate --force

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -70,11 +70,11 @@ then
   cp -ax /var/www/html/vendor/laravel/passport/database/migrations/* /var/www/html/database/migrations/
 fi
 
-exec supervisord -c /supervisord.conf
-
-if [ "${SESSION_DRIVER}" == "database" ]; then
-  cp -ax /var/www/html/vendor/laravel/framework/src/Illuminate/Session/Console/stubs/database.stub /var/www/html/database/migrations/create_sessions_table.php
+if [ $SESSION_DRIVER = "database" ]; then
+  cp -ax /var/www/html/vendor/laravel/framework/src/Illuminate/Session/Console/stubs/database.stub /var/www/html/database/migrations/2021_05_06_0000_create_sessions_table.php
 fi
+
+exec supervisord -c /supervisord.conf
 
 php artisan migrate --force
 php artisan config:clear


### PR DESCRIPTION
Updated entry points so that session table is created and migrate it to the database if it has not been previously migrated if SESSION_DRIVER env var is set to `database`.